### PR TITLE
fix: close the file before exiting the program

### DIFF
--- a/lab_demo/wordle/wordle.c
+++ b/lab_demo/wordle/wordle.c
@@ -94,6 +94,9 @@ int main(int argc, string argv[])
     // Print the game's result
     // TODO #7
 
+    // close file
+    fclose(wordlist);
+
     // that's all folks!
     return 0;
 }


### PR DESCRIPTION
This commit removes the memory leak that can be seen when using `valgrind`.

```
==25298== 
==25298== HEAP SUMMARY:
==25298==     in use at exit: 472 bytes in 1 blocks
==25298==   total heap usage: 53 allocs, 52 frees, 5,970 bytes allocated
==25298== 
==25298== 472 bytes in 1 blocks are still reachable in loss record 1 of 1
==25298==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25298==    by 0x4A076CD: __fopen_internal (iofopen.c:65)
==25298==    by 0x4A076CD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==25298==    by 0x10927D: main (wordle.c:53)
==25298== 
==25298== LEAK SUMMARY:
==25298==    definitely lost: 0 bytes in 0 blocks
==25298==    indirectly lost: 0 bytes in 0 blocks
==25298==      possibly lost: 0 bytes in 0 blocks
==25298==    still reachable: 472 bytes in 1 blocks
==25298==         suppressed: 0 bytes in 0 blocks
==25298== 
==25298== For lists of detected and suppressed errors, rerun with: -s
==25298== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```